### PR TITLE
EPMCUXDA-6630,6635,6646: Add, edit and remove Observation

### DIFF
--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -52,8 +52,6 @@ export default class ObservationController extends AbstractController {
 
   private addObservation = async (req: Request, res: Response, next: NextFunction) => {
     const rawObservation = req.body;
-    if (!req.user) res.status(401).send();
-
     try {
       const newObservation = await Observation.create({ ...rawObservation, finder: req.user.id });
       await this.validate(newObservation);
@@ -77,8 +75,8 @@ export default class ObservationController extends AbstractController {
     const { observation }: { observation: Observation } = req;
     const rawObservation = req.body;
     try {
+      await this.validate(rawObservation, observation);
       const updatedObservation = await this.observations.merge(observation, rawObservation);
-      await this.validate(rawObservation);
       const result = await this.observations.save(updatedObservation);
       res.json(result);
     } catch (e) {

--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -21,26 +21,17 @@ export default class ObservationController extends AbstractController {
     this.router = Router();
     this.observations = getRepository(Observation);
     this.setMainEntity(this.observations, 'observation');
+    this.router.param('id', this.checkId);
 
     this.router.get('/', this.findObservations);
-    this.router.post('/', this.addObservation);
 
-    this.router.param('id', this.checkId);
-    this.router.get('/:id', this.findOne);
-    this.router.delete('/:id', this.remove);
+    this.router.post('/', this.addObservation);
+    this.router.get('/:id', this.findObservation);
+    this.router.put('/:id', this.editObservation);
+    this.router.delete('/:id', this.removeObservation);
 
     return this.router;
   }
-
-  private remove = async (req: RequestWithObservation, res: Response, next: NextFunction): Promise<void> => {
-    const { observation }: { observation: Observation } = req;
-    try {
-      await this.observations.remove(observation);
-      res.json({ id: req.params.id, removed: true });
-    } catch (e) {
-      next(e);
-    }
-  };
 
   private findObservations = async (req: RequestWithPageParams, res: Response, next: NextFunction): Promise<void> => {
     try {
@@ -60,26 +51,46 @@ export default class ObservationController extends AbstractController {
   };
 
   private addObservation = async (req: Request, res: Response, next: NextFunction) => {
-    const newObservation = req.body;
-    if (!req.user) {
-      return res.status(401).send();
-    }
-
-    // validation of Observation fields should be somewhere here
+    const rawObservation = req.body;
+    if (!req.user) res.status(401).send();
 
     try {
-      const observation = await Observation.create({ ...newObservation, finder: req.user.id });
-      const result = await this.observations.save(observation);
-      return res.json(result);
+      const newObservation = await Observation.create({ ...rawObservation, finder: req.user.id });
+      await this.validate(newObservation);
+      const result = await this.observations.save(newObservation);
+      res.json(result);
     } catch (e) {
-      return next(e);
+      next(e);
     }
   };
 
-  private findOne = (req: RequestWithObservation, res: Response, next: NextFunction): void => {
+  private findObservation = async (req: RequestWithObservation, res: Response, next: NextFunction) => {
     const { observation }: { observation: Observation } = req;
     try {
       res.json(observation);
+    } catch (e) {
+      next(e);
+    }
+  };
+
+  private editObservation = async (req: RequestWithObservation, res: Response, next: NextFunction) => {
+    const { observation }: { observation: Observation } = req;
+    const rawObservation = req.body;
+    try {
+      const updatedObservation = await this.observations.merge(observation, rawObservation);
+      await this.validate(rawObservation);
+      const result = await this.observations.save(updatedObservation);
+      res.json(result);
+    } catch (e) {
+      next(e);
+    }
+  };
+
+  private removeObservation = async (req: RequestWithObservation, res: Response, next: NextFunction): Promise<void> => {
+    const { observation }: { observation: Observation } = req;
+    try {
+      const result = await this.observations.remove(observation);
+      res.json(result);
     } catch (e) {
       next(e);
     }

--- a/src/entities/observation-entity.ts
+++ b/src/entities/observation-entity.ts
@@ -2,7 +2,7 @@ import { Entity, Column, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import {
   IsUUID,
   Length,
-  IsDate,
+  IsDateString,
   IsString,
   IsOptional,
   IsAlpha,
@@ -152,7 +152,7 @@ export class Observation {
   })
   public catchingLures: CatchingLures;
 
-  @IsDate()
+  @IsDateString()
   @Column('varchar', { nullable: true, default: null })
   public date: Date | null;
 

--- a/swagger.json
+++ b/swagger.json
@@ -41,6 +41,19 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": ["Observation controller"],
+        "summary": "Add observation",
+        "produces": ["application/json"],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Observation"
+            }
+          }
+        }
       }
     },
     "/observations/{id}": {
@@ -48,6 +61,28 @@
         "tags": ["Observation controller"],
         "produces": ["application/json"],
         "summary": "Get observation by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of observation",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Observation"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Observation controller"],
+        "summary": "Edit observation with provided id",
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "id",
@@ -83,7 +118,7 @@
           "200": {
             "description": "successful operation",
             "schema": {
-              "$ref": "#/definitions/RemoveByIdResponse"
+              "$ref": "#/definitions/Observation"
             }
           }
         }


### PR DESCRIPTION
### What does this PR do?

Adds 3 out of 4 CRUD operations for Observation: add, edit and remove.
Edit is the new one, add and remove are modified.

### Jira ticket related to this PR

- [EPMCUXDA-6630](https://jira.epam.com/jira/browse/EPMCUXDA-6630)
- [EPMCUXDA-6635](https://jira.epam.com/jira/browse/EPMCUXDA-6635)
- [EPMCUXDA-6646](https://jira.epam.com/jira/browse/EPMCUXDA-6646)

#### Type of change

`What types of changes does your code introduce? Put an 'x' in all the boxes that apply:`

- [x] Adds new features.
- [x] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [ ] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.

### Questions (if any)

When the operation is successfully completed, should we return a target observation 
`res.json(observation)` or just some generic object with traget observation id `res.json({ id: observation.id, success: true })`?