### PR TITLE
update flow for updating observation

### DIFF
--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -107,7 +107,12 @@ export default class ObservationController extends AbstractController {
     const { observation }: { observation: Observation } = req;
     const rawObservation = req.body;
     try {
-      await this.validate(rawObservation, observation);
+      let { ring } = rawObservation;
+      if (!ring || rawObservation.ringMentioned !== observation.ringMentioned) {
+        ({ id: ring = null } =
+          (await this.rings.findOne({ identificationNumber: rawObservation.ringMentioned })) || {});
+      }
+      await this.validate(Object.assign(rawObservation, { ring }), observation);
       const updatedObservation = await this.observations.merge(observation, rawObservation);
       const result = await this.observations.save(updatedObservation);
       res.json(result);


### PR DESCRIPTION
### What does this PR do?

With the latest updates of the `Observation`'s model, the logic of the `Observation` update is updated.
A number of facts are taken into account:
- A ring could be added to the database after the observation itself has been added, and ring will be added as a ref
- the ring number could be clarified, corrected, the ring would also be added as a ref

In general, from the client's point of view, this logic is very rough and should be applied on the client. I mean client requests for `ring`s by providing `ringMentioned`

### Link to branch and/or PR's related

- #35 - Add, edit and remove Observation 
- #44 - Update ring relation and field to store ring as string

#### Type of change

- [ ] Adds new features.
- [x] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [ ] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.
