### PR TITLE
fix: Adjust Win-machines to properly work with line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,6 +3,7 @@ module.exports = {
   trailingComma: 'all',
   singleQuote: true,
   bracketSpacing: true,
+  endOfLine: 'lf',
   printWidth: 120,
   tabWidth: 2,
   overrides: [


### PR DESCRIPTION
### What does this PR do?

Fixes case when Win-machine overrides line-endings to `CRLF` when clones repo by default. Also support this by directly set up prettier to work with `LF`

### How should I test this?

Try to clone repo and confirm that there are only project-based endings: `LF`

#### Type of change

- [ ] Adds new features.
- [ ] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [ ] Fixes any bug.
- [x] Other: security, build process, infrastructure, tests, docs, etc.

