### PR TITLE
update: EPMCUXDA-7403: separate user updating by reponsibilities

### DIFF
--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -45,7 +45,9 @@ export default class UsersController extends AbstractController {
     @PathParam('id') id: string,
     @ContextRequest req: Request,
   ): Promise<{} | void> {
-    console.log(req);
+    if (id !== req.user.id) {
+      throw new CustomError('Unauthorized', 401);
+    }
     const { password, newPassword } = body;
     // todo check that password corresponds some requirements
     if (!password || !newPassword) {

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -121,10 +121,14 @@ export default class UsersController extends AbstractController {
   @PreProcessor(auth.role(UserRole.Admin))
   @Response<{}>(200, 'Role successfully updated.')
   @Response<CustomError>(400, 'Role is required')
+  @Response<CustomError>(400, 'Provided role is unsupported')
   public async updateRole(body: any, @PathParam('id') id: string): Promise<{} | void> {
     const { role } = body;
     if (!role) {
       throw new CustomError('Role is required', 400);
+    }
+    if (!UserRole[role]) {
+      throw new CustomError('Provided role is unsupported', 400);
     }
     const user: User = await this.getEntityById<User>(id);
 

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -62,13 +62,14 @@ export default class UsersController extends AbstractController {
   @Path('/:id')
   @Response<void>(204, 'User successfully updated')
   @Response<CustomError>(401, 'Unauthorised')
+  @Response<CustomError>(403, 'Forbidden')
   public async updateUser(
     body: UpdateUserDto,
     @PathParam('id') id: string,
     @ContextRequest req: Request & { user: User },
   ): Promise<void> {
     if (id !== req.user.id) {
-      throw new CustomError('Unauthorized', 401);
+      throw new CustomError('Forbidden', 403);
     }
     const { firstName, lastName } = body;
 
@@ -89,13 +90,14 @@ export default class UsersController extends AbstractController {
   @Response<void>(204, 'Password successfully updated')
   @Response<CustomError>(400, 'Both User old and new passwords are required')
   @Response<CustomError>(401, 'Unauthorised || Wrong Password')
+  @Response<CustomError>(403, 'Forbidden')
   public async updatePassword(
     body: UpdateUserPasswordDto,
     @PathParam('id') id: string,
     @ContextRequest req: Request & { user: User },
   ): Promise<void> {
     if (id !== req.user.id) {
-      throw new CustomError('Unauthorized', 401);
+      throw new CustomError('Forbidden', 403);
     }
     const { password, newPassword } = body;
     // todo check that password corresponds some requirements
@@ -121,15 +123,15 @@ export default class UsersController extends AbstractController {
   @Path('/:id/update-email')
   @Response<void>(204, 'Email successfully updated')
   @Response<CustomError>(400, 'Both User password and new email are required')
-  @Response<CustomError>(401, 'Unauthorised')
-  @Response<CustomError>(401, 'Invalid password')
+  @Response<CustomError>(401, 'Unauthorised || Wrong password')
+  @Response<CustomError>(403, 'Forbidden')
   public async updateEmail(
     body: UpdateUserEmailDto,
     @PathParam('id') id: string,
     @ContextRequest req: Request & { user: User },
   ): Promise<void> {
     if (id !== req.user.id) {
-      throw new CustomError('Unauthorized', 401);
+      throw new CustomError('Forbidden', 403);
     }
     const { password, newEmail } = body;
     // todo check that password corresponds some requirements
@@ -157,6 +159,8 @@ export default class UsersController extends AbstractController {
   @PreProcessor(auth.role(UserRole.Admin))
   @Response<void>(204, 'Role successfully updated.')
   @Response<CustomError>(400, 'Role is required || Provided role is unsupported')
+  @Response<CustomError>(401, 'Unauthorised')
+  @Response<CustomError>(403, 'Forbidden')
   public async updateRole(body: UpdateUserRoleDto, @PathParam('id') id: string): Promise<void> {
     const { role } = body;
     if (!role) {
@@ -182,6 +186,7 @@ export default class UsersController extends AbstractController {
   @PreProcessor(auth.role(UserRole.Admin))
   @Response<{ id: string; removed: boolean }>(200, 'User with passed id successfully deleted.')
   @Response<CustomError>(401, 'Unauthorised.')
+  @Response<CustomError>(403, 'Forbidden.')
   public async remove(@PathParam('id') id: string): Promise<{ id: string; removed: boolean }> {
     const user = await this.getEntityById<User>(id);
     await this.users.remove(user);

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -41,7 +41,14 @@ export default class UsersController extends AbstractController {
   @Path('/:id')
   @Response<{}>(200, 'User successfully updated')
   @Response<CustomError>(401, 'Unauthorised')
-  public async updateUser(body: any, @PathParam('id') id: string): Promise<{} | void> {
+  public async updateUser(
+    body: any,
+    @PathParam('id') id: string,
+    @ContextRequest req: Request & { user: User },
+  ): Promise<{} | void> {
+    if (id !== req.user.id) {
+      throw new CustomError('Unauthorized', 401);
+    }
     const { firstName, lastName } = body as User;
 
     const user: User = await this.getEntityById<User>(id);

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -87,9 +87,8 @@ export default class UsersController extends AbstractController {
   @PUT
   @Path('/:id/update-password')
   @Response<void>(204, 'Password successfully updated')
-  @Response<CustomError>(401, 'Unauthorised')
-  @Response<CustomError>(401, 'Invalid password')
   @Response<CustomError>(400, 'Both User old and new passwords are required')
+  @Response<CustomError>(401, 'Unauthorised || Wrong Password')
   public async updatePassword(
     body: UpdateUserPasswordDto,
     @PathParam('id') id: string,
@@ -105,7 +104,7 @@ export default class UsersController extends AbstractController {
     }
     const user: User = await this.getEntityById<User>(id);
     if (!(await isCorrect(password, user.salt, user.hash))) {
-      throw new CustomError('Invalid password', 401);
+      throw new CustomError('Wrong password', 401);
     }
 
     await user.setPassword(password);
@@ -121,9 +120,9 @@ export default class UsersController extends AbstractController {
   @PUT
   @Path('/:id/update-email')
   @Response<void>(204, 'Email successfully updated')
+  @Response<CustomError>(400, 'Both User password and new email are required')
   @Response<CustomError>(401, 'Unauthorised')
   @Response<CustomError>(401, 'Invalid password')
-  @Response<CustomError>(400, 'Both User password and new email are required')
   public async updateEmail(
     body: UpdateUserEmailDto,
     @PathParam('id') id: string,
@@ -157,8 +156,7 @@ export default class UsersController extends AbstractController {
   @Path('/:id/update-role')
   @PreProcessor(auth.role(UserRole.Admin))
   @Response<void>(204, 'Role successfully updated.')
-  @Response<CustomError>(400, 'Role is required')
-  @Response<CustomError>(400, 'Provided role is unsupported')
+  @Response<CustomError>(400, 'Role is required || Provided role is unsupported')
   public async updateRole(body: UpdateUserRoleDto, @PathParam('id') id: string): Promise<void> {
     const { role } = body;
     if (!role) {

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -67,7 +67,7 @@ export default class UsersController extends AbstractController {
   public async updatePassword(
     body: any,
     @PathParam('id') id: string,
-    @ContextRequest req: Request,
+    @ContextRequest req: Request & { user: User },
   ): Promise<{} | void> {
     if (id !== req.user.id) {
       throw new CustomError('Unauthorized', 401);
@@ -93,7 +93,11 @@ export default class UsersController extends AbstractController {
   @Response<CustomError>(401, 'Unauthorised')
   @Response<CustomError>(401, 'Invalid password')
   @Response<CustomError>(400, 'Both User password and new email are required')
-  public async updateEmail(body: any, @PathParam('id') id: string, @ContextRequest req: Request): Promise<{} | void> {
+  public async updateEmail(
+    body: any,
+    @PathParam('id') id: string,
+    @ContextRequest req: Request & { user: User },
+  ): Promise<{} | void> {
     if (id !== req.user.id) {
       throw new CustomError('Unauthorized', 401);
     }

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -38,13 +38,13 @@ export default class UsersController extends AbstractController {
 
   @PUT
   @Path('/:id')
-  @Response<{}>(200, 'User successfully updated')
+  @Response<void>(204, 'User successfully updated')
   @Response<CustomError>(401, 'Unauthorised')
   public async updateUser(
     body: any,
     @PathParam('id') id: string,
     @ContextRequest req: Request & { user: User },
-  ): Promise<{} | void> {
+  ): Promise<void> {
     if (id !== req.user.id) {
       throw new CustomError('Unauthorized', 401);
     }
@@ -54,12 +54,11 @@ export default class UsersController extends AbstractController {
     const newUser = Object.assign(user, { lastName, firstName });
     await this.validate(newUser);
     await this.users.save(newUser);
-    return {};
   }
 
   @PUT
   @Path('/:id/update-password')
-  @Response<{}>(200, 'Password successfully updated')
+  @Response<void>(204, 'Password successfully updated')
   @Response<CustomError>(401, 'Unauthorised')
   @Response<CustomError>(401, 'Invalid password')
   @Response<CustomError>(400, 'Both User old and new passwords are required')
@@ -67,7 +66,7 @@ export default class UsersController extends AbstractController {
     body: any,
     @PathParam('id') id: string,
     @ContextRequest req: Request & { user: User },
-  ): Promise<{} | void> {
+  ): Promise<void> {
     if (id !== req.user.id) {
       throw new CustomError('Unauthorized', 401);
     }
@@ -83,12 +82,11 @@ export default class UsersController extends AbstractController {
 
     await user.setPassword(password);
     await this.users.save(user);
-    return {};
   }
 
   @PUT
   @Path('/:id/update-email')
-  @Response<{}>(200, 'Email successfully updated')
+  @Response<void>(204, 'Email successfully updated')
   @Response<CustomError>(401, 'Unauthorised')
   @Response<CustomError>(401, 'Invalid password')
   @Response<CustomError>(400, 'Both User password and new email are required')
@@ -96,7 +94,7 @@ export default class UsersController extends AbstractController {
     body: any,
     @PathParam('id') id: string,
     @ContextRequest req: Request & { user: User },
-  ): Promise<{} | void> {
+  ): Promise<void> {
     if (id !== req.user.id) {
       throw new CustomError('Unauthorized', 401);
     }
@@ -113,16 +111,15 @@ export default class UsersController extends AbstractController {
     user.email = newEmail;
     await this.validate(user);
     await this.users.save(user);
-    return {};
   }
 
   @PUT
   @Path('/:id/update-role')
   @PreProcessor(auth.role(UserRole.Admin))
-  @Response<{}>(200, 'Role successfully updated.')
+  @Response<void>(204, 'Role successfully updated.')
   @Response<CustomError>(400, 'Role is required')
   @Response<CustomError>(400, 'Provided role is unsupported')
-  public async updateRole(body: any, @PathParam('id') id: string): Promise<{} | void> {
+  public async updateRole(body: any, @PathParam('id') id: string): Promise<void> {
     const { role } = body;
     if (!role) {
       throw new CustomError('Role is required', 400);
@@ -134,7 +131,6 @@ export default class UsersController extends AbstractController {
 
     user.role = role;
     await this.users.save(user);
-    return {};
   }
 
   @DELETE

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -82,7 +82,7 @@ export default class UsersController extends AbstractController {
 
   @PUT
   @Path('/:id/update-email')
-  @Response<{}>(200, 'Password successfully updated')
+  @Response<{}>(200, 'Email successfully updated')
   @Response<CustomError>(401, 'Unauthorised')
   @Response<CustomError>(401, 'Invalid password')
   @Response<CustomError>(400, 'Both User password and new email are required')

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -4,7 +4,6 @@ import { DELETE, GET, PUT, Path, PathParam, PreProcessor, Security, ContextReque
 import { Tags, Response } from 'typescript-rest-swagger';
 import AbstractController from './abstract-controller';
 import { User, UserRole } from '../entities/user-entity';
-import { Ring } from '../entities/ring-entity';
 import { CustomError } from '../utils/CustomError';
 import { auth } from '../services/auth-service';
 import { isCorrect } from '../services/user-crypto-service';
@@ -31,7 +30,7 @@ export default class UsersController extends AbstractController {
 
   @GET
   @Path('/:id')
-  @Response<Ring>(200, 'User with passed id.')
+  @Response<User>(200, 'User with passed id.')
   @Response<CustomError>(401, 'Unauthorised.')
   public async findOne(@PathParam('id') id: string): Promise<User> {
     return this.getEntityById<User>(id);

--- a/src/entities/user-entity.ts
+++ b/src/entities/user-entity.ts
@@ -26,6 +26,25 @@ export interface NewUser {
 
 export interface CreateUserDto extends NewUser, WithCredentials {}
 
+export interface UpdateUserDto {
+  firstName?: string;
+  lastName?: string;
+}
+
+export interface UpdateUserEmailDto {
+  newEmail: string;
+  password: string;
+}
+
+export interface UpdateUserPasswordDto {
+  newPassword: string;
+  password: string;
+}
+
+export interface UpdateUserRoleDto {
+  role: UserRole;
+}
+
 export interface UserDto extends NewUser {
   id: string;
   role: UserRole;


### PR DESCRIPTION
### What does this PR do?

Adds 4 endpoints to update user by:

- `email` - in order to change this field, you need to provide a **password** at least. There is also a limitation that this field can only be changed by the **user itself**.
- `password` - in order to change this field, you need to provide **both passwords**. There is also a limitation that this field can only be changed by the **user itself**.
- `role` - implies that only the **administrator** can change the user role.
- all other fields (currently `firstName`, and `lastName`). There is a limitation that this field can only be changed by the **user itself**.

This is done in order to share responsibility for different operations, all the more so because they have different requirements: incoming parameters, roles, matching of the changed user to the modifying one.

Further it is possible to expand for some cases, but while works `checkUserRole ` does not allow to adjust it flexibly, it is possible to check up on demand what role at modifier is it admin, but nevertheless -- user wouldn't  update itself.

### How should I test this?

todo

### Jira ticket related to this PR

- [EPMCUXDA-7403](https://jira.epam.com/jira/browse/EPMCUXDA-7403)

### Type of change

- [x] Adds new features.
- [ ] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [ ] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.
