### PR TITLE
Feature: EPMCUXDA-7529 User places

### DIFF
--- a/src/controllers/abstract-controller.ts
+++ b/src/controllers/abstract-controller.ts
@@ -9,6 +9,11 @@ interface ParsedErrors {
   [key: string]: string[];
 }
 
+interface ConstructorFabric {
+  create(...args: any): any;
+  new (): any;
+}
+
 export default abstract class AbstractController {
   private entity: Repository<any>;
 
@@ -37,8 +42,8 @@ export default abstract class AbstractController {
   }
 
   // Argument 'data' it is a new data, and argument existedData is optional and needed for refreshing existing data in db
-  protected async validate(data: any, existedData: any = {}): Promise<void> {
-    const createdModel = await this.entity.create(Object.assign(existedData, data));
+  protected async validate(data: any, existedData: any = {}, entity?: ConstructorFabric): Promise<void> {
+    const createdModel = await (entity || this.entity).create(Object.assign(existedData, data));
     const errors = await validate(createdModel);
     if (errors.length) {
       const parsedErrors = errors.reduce(

--- a/src/controllers/abstract-controller.ts
+++ b/src/controllers/abstract-controller.ts
@@ -10,8 +10,8 @@ interface ParsedErrors {
 }
 
 interface ConstructorFabric {
-  create(...args: any): any;
-  new (): any;
+  create(...args: any): Record<string, any>;
+  new (): {};
 }
 
 export default abstract class AbstractController {

--- a/src/controllers/users-controller.ts
+++ b/src/controllers/users-controller.ts
@@ -10,6 +10,7 @@ import {
   UpdateUserEmailDto,
   UpdateUserRoleDto,
   UpdateUserPasswordDto,
+  UpdateUserPlacesDto,
 } from '../entities/user-entity';
 import { CustomError } from '../utils/CustomError';
 import { auth } from '../services/auth-service';
@@ -173,6 +174,25 @@ export default class UsersController extends AbstractController {
     const user: User = await this.getEntityById<User>(id);
 
     user.role = role;
+    await this.users.save(user);
+  }
+
+  /**
+   * Update user places by id
+   * @param {UpdateUserPlacesDto} body Array of updated places
+   * @param {string} id Id of updated user
+   */
+
+  @PUT
+  @Path('/:id/update-places')
+  @Response<void>(204, 'Places successfully updated.')
+  @Response<CustomError>(401, 'Unauthorised')
+  @Response<CustomError>(403, 'Forbidden')
+  public async updatePlaces(body: UpdateUserPlacesDto, @PathParam('id') id: string): Promise<void> {
+    const { places } = body;
+    // todo add validation
+    const user: User = await this.getEntityById<User>(id);
+    user.places = places;
     await this.users.save(user);
   }
 

--- a/src/entities/submodels/UserPlace.ts
+++ b/src/entities/submodels/UserPlace.ts
@@ -1,0 +1,24 @@
+import { IsString, IsOptional, IsNumber, Min, Max } from 'class-validator';
+
+export default class UserPlace {
+  @IsString()
+  public customName: string;
+
+  @IsOptional()
+  @IsString()
+  public geoName?: string;
+
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  public latitude: number;
+
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  public longitude: number;
+
+  public static create(values: UserPlace) {
+    return Object.assign(new UserPlace(), values);
+  }
+}

--- a/src/entities/user-entity.ts
+++ b/src/entities/user-entity.ts
@@ -57,6 +57,10 @@ export interface UserPlace {
   longitude: number;
 }
 
+export interface UpdateUserPlacesDto {
+  places: UserPlace[];
+}
+
 @Entity()
 export class User implements UserDto {
   @PrimaryGeneratedColumn('uuid')

--- a/src/entities/user-entity.ts
+++ b/src/entities/user-entity.ts
@@ -50,6 +50,13 @@ export interface UserDto extends NewUser {
   role: UserRole;
 }
 
+export interface UserPlace {
+  customName: string;
+  geoName: string;
+  latitude: number;
+  longitude: number;
+}
+
 @Entity()
 export class User implements UserDto {
   @PrimaryGeneratedColumn('uuid')
@@ -84,6 +91,10 @@ export class User implements UserDto {
   @MaxLength(64)
   @Column('varchar', { length: 64, nullable: true, default: null })
   public lastName?: string;
+
+  @IsOptional()
+  @Column('jsonb', { nullable: true })
+  public places?: UserPlace[];
 
   @Column()
   public hash: string;

--- a/src/entities/user-entity.ts
+++ b/src/entities/user-entity.ts
@@ -1,9 +1,10 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
-import { IsEmail, MinLength, MaxLength, IsEnum, IsString, IsOptional } from 'class-validator';
+import { IsEmail, MinLength, MaxLength, IsEnum, IsString, IsOptional, IsArray } from 'class-validator';
 import { getSaltAndHash } from '../services/user-crypto-service';
 import { Observation } from './observation-entity';
 import { Ring } from './ring-entity';
 import { BasaRing } from './basa-ring-entity';
+import UserPlace from './submodels/UserPlace';
 
 export interface WithCredentials {
   email: string;
@@ -50,13 +51,6 @@ export interface UserDto extends NewUser {
   role: UserRole;
 }
 
-export interface UserPlace {
-  customName: string;
-  geoName: string;
-  latitude: number;
-  longitude: number;
-}
-
 export interface UpdateUserPlacesDto {
   places: UserPlace[];
 }
@@ -97,7 +91,8 @@ export class User implements UserDto {
   public lastName?: string;
 
   @IsOptional()
-  @Column('jsonb', { nullable: true })
+  @IsArray()
+  @Column('jsonb', { nullable: true, default: null })
   public places?: UserPlace[];
 
   @Column()


### PR DESCRIPTION
### What does this PR do?

It adds 
- a new field to the user model: `places: UserPlace[]` 
- and accordingly a new PUT endpoint `users/:id/update-places` to update them.

This endpoint works on a simple principle of overwriting all the places at once -- that is, **you need to send all the places and updated and not.**

Each place is validated, and if several of them are incorrect, errors will be returned for what was failed first. In this case it responds with **422 Unprocessable Entity**

On successful request will be responded with code **204 No Content**

The model of places is as follows:

```ts
interface UserPlace {
  customName: string;
  geoName?: string;
  latitude: number;
  longitude: number;
}
```



### How should I test this?
F.e. with my working testing case:
```json
{"places": [
  {
    "customName":"forest near grandma village", 
    "longitude": 24.31, 
    "latitude":-54.34
  }
]}
```

and not:
```json
{"places": [
  {"customName":"myfav[lace"}
]}
```


### Jira ticket related to this PR

- [EPMCUXDA-7529](https://jira.epam.com/jira/browse/EPMCUXDA-7529)

### Type of change

- [x] Adds new features.
- [ ] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [ ] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.