### PR TITLE
fix: observations aggregation with null values

### DIFF
--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -146,7 +146,7 @@ export default class ObservationController extends AbstractController {
       this.requiredColumns.forEach(column => {
         const desired = acc[column].find(({ value, value: { id } = {} }) => {
           if (typeof observation[column] === 'object' && observation[column] !== null && id) {
-            return id === (observation[column] as any).id;
+            return id === (observation[column] as Record<string, any>).id;
           }
           return value === observation[column];
         });

--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -66,7 +66,7 @@ export default class ObservationController extends AbstractController {
 
   private importer: Importer;
 
-  private requiredColumns: ObservationKeyUnion[] = ['speciesMentioned', 'verified', 'finder', 'ringMentioned'];
+  private aggregatedColumns: ObservationKeyUnion[] = ['speciesMentioned', 'verified', 'finder', 'ringMentioned'];
 
   public constructor() {
     super();
@@ -138,30 +138,33 @@ export default class ObservationController extends AbstractController {
 
     const paramsAggregation = parseWhereParams(user, query);
     const observations = await this.observations.find({ ...paramsAggregation });
-    const requiredColumnsMap: AggregationsMap = this.requiredColumns.reduce((acc, column) => {
-      return Object.assign(acc, { [column]: [] });
-    }, {});
+    const aggregationMap: AggregationsMap = this.aggregatedColumns.reduce(
+      (map, column) => Object.assign(map, { [column]: [] }),
+      {},
+    );
 
-    return observations.reduce((acc, observation) => {
-      this.requiredColumns.forEach(column => {
-        const desired = acc[column].find(({ value, value: { id } = {} }) => {
+    return observations.reduce((aggregation, observation) => {
+      this.aggregatedColumns.forEach(column => {
+        const desired = aggregation[column].find(({ value, value: { id } }) => {
           if (typeof observation[column] === 'object' && observation[column] !== null && id) {
             return id === (observation[column] as Record<string, any>).id;
           }
           return value === observation[column];
         });
+
         if (desired) {
           desired.count += 1;
         } else {
           const f = pipe((arg: [string, any]) => sanitizeUser(arg));
           const [, value] = f([column, observation[column]]);
+          // readme disable aggregation by untruly values:  at first null
           if (value !== null) {
-            acc[column].push({ value, count: 1 });
+            aggregation[column].push({ value, count: 1 });
           }
         }
       });
-      return acc;
-    }, requiredColumnsMap);
+      return aggregation;
+    }, aggregationMap);
   }
 
   /**

--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -155,7 +155,9 @@ export default class ObservationController extends AbstractController {
         } else {
           const f = pipe((arg: [string, any]) => sanitizeUser(arg));
           const [, value] = f([column, observation[column]]);
-          acc[column].push({ value, count: 1 });
+          if (value !== null) {
+            acc[column].push({ value, count: 1 });
+          }
         }
       });
       return acc;

--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -144,11 +144,11 @@ export default class ObservationController extends AbstractController {
 
     return observations.reduce((acc, observation) => {
       this.requiredColumns.forEach(column => {
-        const desired = acc[column].find(item => {
-          if (typeof observation[column] === 'object' && observation[column] !== null) {
-            return item.value.id === (observation[column] as any).id;
+        const desired = acc[column].find(({ value, value: { id } = {} }) => {
+          if (typeof observation[column] === 'object' && observation[column] !== null && id) {
+            return id === (observation[column] as any).id;
           }
-          return item.value === observation[column];
+          return value === observation[column];
         });
         if (desired) {
           desired.count += 1;


### PR DESCRIPTION
### What does this PR do?

Removes from aggregations values with `null`. 

- As at first it not so meaningful
- at second it fail clients -- they not support `null` values
- at third it also break server on `observations/aggregations`.

Also it renames bunch of variables involved in aggregations.

Essentially, this PR is correction of the **unaccounted consequences** of the update of the ring and observation model coming from #32 (import from access)



### How should I test this?

Try to request `observations/aggregations` by different users

### Link to branch and/or PR's related

- #32 Import of other entities from Access

### Type of change

- [ ] Adds new features.
- [ ] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [x] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.
