### PR TITLE
update(Observation): fill its props connected with ring

### DIFF
--- a/src/controllers/observation-controller.ts
+++ b/src/controllers/observation-controller.ts
@@ -231,6 +231,8 @@ export default class ObservationController extends AbstractController {
         ring = ringEntity.id;
       }
     }
+
+    observation.reFillByRing(observation.ring);
     await this.validate(Object.assign(rawObservation, { ring }), observation);
     // TODO protect from finder updating
     // @ts-ignore see https://github.com/typeorm/typeorm/issues/3490

--- a/src/entities/observation-entity.ts
+++ b/src/entities/observation-entity.ts
@@ -73,8 +73,6 @@ interface RawObservationBase<TCommon, TRing, TSpecies, TPlaceCode> {
   latitude?: number;
   longitude?: number;
   photos?: string[];
-  distance?: number;
-  direction?: number;
   remarks?: string;
   date?: Date;
   accuracyOfDate: TCommon;
@@ -93,6 +91,8 @@ export interface ObservationBase<TFinder, TOfFinder, TCommon, TRing, TSpecies, T
   offlineFinder: TOfFinder;
   offlineFinderNote: string | null;
   elapsedTime: number | null;
+  distance: number | null;
+  direction: number | null;
   colorRing: string | null;
   ringingScheme: EntityDto;
   primaryIdentificationMethod: EntityDto;
@@ -281,7 +281,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   @Min(0)
   @Max(99999)
   @Column('integer', { nullable: true, default: null })
-  public distance: number;
+  public distance: number | null;
 
   // Related field in access 'Derived data directions'
   @IsOptional()
@@ -289,7 +289,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   @Min(0)
   @Max(359)
   @Column('smallint', { nullable: true, default: null })
-  public direction: number;
+  public direction: number | null;
 
   // Related field in access 'Derived data elapsed time'
   @IsOptional()

--- a/src/entities/observation-entity.ts
+++ b/src/entities/observation-entity.ts
@@ -130,6 +130,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   @PrimaryGeneratedColumn('uuid')
   public id: string;
 
+  // Readme it isn't presented in EURING scheme
   @IsOptional()
   @IsUUID()
   @ManyToOne(() => Ring, m => m.observation, {
@@ -137,6 +138,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   })
   public ring: Ring;
 
+  // Readme it isn't presented in EURING scheme
   @IsOptional()
   @IsString()
   @Length(10, 10, { message: equalLength(10) })
@@ -147,6 +149,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
     return this.ringMentioned;
   }
 
+  // Readme it isn't presented in EURING scheme
   @IsOptional()
   @IsUUID()
   @ManyToOne(() => User, m => m.observation, {
@@ -154,12 +157,14 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   })
   public finder: User;
 
+  // Readme it isn't presented in EURING scheme
   @IsUUID()
   @ManyToOne(() => Person, m => m.observation, {
     eager: true,
   })
   public offlineFinder: Person;
 
+  // Readme it isn't presented in EURING scheme
   @IsOptional()
   @IsString()
   @Column('varchar', { nullable: true, default: null })
@@ -167,6 +172,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   // in other words it's alternate to offlineFinder field to store data
   public offlineFinderNote: string | null;
 
+  // Readme ofc that it isn't presented in EURING scheme
   @IsOptional()
   @IsString({ each: true })
   @Column('varchar', { array: true, nullable: true, default: null })
@@ -293,7 +299,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   @Column('integer', { nullable: true, default: null })
   public elapsedTime: number | null;
 
-  // Not presented in euring standart
+  // README colorRing isn't presented in euring standard
   @IsOptional()
   @IsString()
   @Column('varchar', { nullable: true, default: null })
@@ -450,7 +456,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   @Column('varchar', { nullable: true, default: null })
   public remarks: string;
 
-  // Not presented in euring standart
+  // README verified isn't presented in euring standard
   @IsOptional()
   @IsEnum(Verified)
   @Column({

--- a/src/entities/observation-entity.ts
+++ b/src/entities/observation-entity.ts
@@ -252,7 +252,7 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
   @ManyToOne(() => Sex, m => m.concludedInObservation, {
     eager: true,
   })
-  public sexConcluded: Species;
+  public sexConcluded: Sex;
 
   @IsAlphanumeric()
   @Length(1, 1, { message: equalLength(1) })

--- a/src/entities/observation-entity.ts
+++ b/src/entities/observation-entity.ts
@@ -51,6 +51,9 @@ import { ColumnNumericTransformer } from '../utils/ColumnNumericTransformer';
 import { fromDateToEuringDate, fromDateToEuringTime, fromEuringToDate } from '../utils/date-parser';
 import { fromDecimalToEuring, DecimalCoordinates, fromEuringToDecimal } from '../utils/coords-parser';
 import { fromStringToValueOrNull, fromNumberToPaddedString } from '../utils/custom-parsers';
+import directionBy2PointsWithLnLt from '../utils/directionBy2PointsWithLnLt';
+import elapsedTimeBetween2Dates from '../utils/elapsedTimeBetween2Dates';
+import distanceBy2PointsWithLnLt from '../utils/distanceBy2PointsWithLnLt';
 
 export interface NewObservation {
   finder: User;
@@ -470,6 +473,18 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
     return Object.assign(new Observation(), observation);
   }
 
+  public reFillByRing(ring: Ring): void {
+    if (!ring) return;
+    const { speciesConcluded, ageConcluded, sexConcluded } = ring;
+    this.ring.id = ring.id;
+    this.speciesConcluded = speciesConcluded || null;
+    this.ageConcluded = ageConcluded || null;
+    this.sexConcluded = sexConcluded || null;
+    this.direction = directionBy2PointsWithLnLt(this, ring);
+    this.elapsedTime = elapsedTimeBetween2Dates(this, ring);
+    this.distance = distanceBy2PointsWithLnLt(this, ring);
+  }
+
   public exportEURING(): string {
     return [
       this.ringingScheme.id,
@@ -501,8 +516,8 @@ export class Observation implements ObservationDto, AbleToExportAndImportEuring,
       this.circumstances.id,
       this.circumstancesPresumed.id,
       this.euringCodeIdentifier.id,
-      fromNumberToPaddedString(this.distance, 5) || '-'.repeat(5),
-      fromNumberToPaddedString(this.direction, 3) || '-'.repeat(3),
+      fromNumberToPaddedString(this.distance as number, 5) || '-'.repeat(5),
+      fromNumberToPaddedString(this.direction as number, 3) || '-'.repeat(3),
       fromNumberToPaddedString(this.elapsedTime as number, 5) || '-'.repeat(5),
       // Below unsupported parameters that presented in EURING
       '', // wing length

--- a/src/utils/directionBy2PointsWithLnLt.ts
+++ b/src/utils/directionBy2PointsWithLnLt.ts
@@ -1,0 +1,21 @@
+interface GeoPoint {
+  longitude: number;
+  latitude: number;
+}
+
+export default (end: GeoPoint, start: GeoPoint): number | null => {
+  if (!end.longitude || !end.latitude || !start.longitude || !start.latitude) return null;
+
+  // φ, λ in radians
+  const φ1 = (start.latitude * Math.PI) / 180;
+  const φ2 = (end.latitude * Math.PI) / 180;
+  const λ2 = (end.longitude * Math.PI) / 180;
+  const λ1 = (start.longitude * Math.PI) / 180;
+
+  const y = Math.sin(λ2 - λ1) * Math.cos(φ2);
+  const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(λ2 - λ1);
+  const θ = Math.atan2(y, x);
+  const bearing = ((θ * 180) / Math.PI + 360) % 360; // in degrees
+
+  return bearing;
+};

--- a/src/utils/directionBy2PointsWithLnLt.ts
+++ b/src/utils/directionBy2PointsWithLnLt.ts
@@ -1,6 +1,6 @@
 interface GeoPoint {
-  longitude: number;
-  latitude: number;
+  longitude: number | null;
+  latitude: number | null;
 }
 
 export default (end: GeoPoint, start: GeoPoint): number | null => {

--- a/src/utils/distanceBy2PointsWithLnLt.ts
+++ b/src/utils/distanceBy2PointsWithLnLt.ts
@@ -1,0 +1,20 @@
+interface GeoPoint {
+  longitude: number;
+  latitude: number;
+}
+
+export default (end: GeoPoint, start: GeoPoint): number | null => {
+  if (!end.longitude || !end.latitude || !start.longitude || !start.latitude) return null;
+
+  const R = 6371e3; // Earth radius - metres
+  const φ1 = (start.latitude * Math.PI) / 180; // φ, λ in radians
+  const φ2 = (end.latitude * Math.PI) / 180;
+  const Δφ = ((end.latitude - start.latitude) * Math.PI) / 180;
+  const Δλ = ((end.longitude - start.longitude) * Math.PI) / 180;
+
+  const a = Math.sin(Δφ / 2) * Math.sin(Δφ / 2) + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  const distance = R * c; // in meters
+  return distance / 1000;
+};

--- a/src/utils/distanceBy2PointsWithLnLt.ts
+++ b/src/utils/distanceBy2PointsWithLnLt.ts
@@ -1,6 +1,6 @@
 interface GeoPoint {
-  longitude: number;
-  latitude: number;
+  longitude: number | null;
+  latitude: number | null;
 }
 
 export default (end: GeoPoint, start: GeoPoint): number | null => {

--- a/src/utils/elapsedTimeBetween2Dates.ts
+++ b/src/utils/elapsedTimeBetween2Dates.ts
@@ -1,0 +1,9 @@
+interface TimePoint {
+  date: Date | null;
+}
+
+export default (end: TimePoint, start: TimePoint): number | null => {
+  if (!end.date || !start.date || !(end.date instanceof Date) || !(start.date instanceof Date)) return null;
+  const msInDay = 1000 * 60 * 60 * 24;
+  return Math.ceil((end.date.getTime() - start.date.getTime()) / msInDay);
+};


### PR DESCRIPTION
### What does this PR do?
Updates `Observation` model
- add 3 helping method to calculate `distance`, `elapsedTime`, `direction`
- which are used by `Observation` instance new method `refillByRing` to fill these 3 property + fill 3 other props: `(species|sex|age)Concluded` taking it from related `Ring`.

Other updates:
- as `distance`, `elapsedTime`, `direction` are retrieved from `Ring` they are made optional and nullable in interface and model typings and removed from POST/PUT incoming DTO
- fixed reference to wrong model `sexConcluded` to `Species`

### Jira ticket related to this PR

- [EPMCUXDA-XXXX](https://jira.epam.com/jira/browse/EPMCUXDA-XXXX)

### Type of change

- [x] Adds new features.
- [x] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [x] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.